### PR TITLE
Prevent mobile nav from overlapping page titles

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,7 +1,7 @@
 export default function AboutPage() {
   return (
     <div className="min-h-screen bg-gradient-to-b from-rose-50 via-pink-50 to-purple-50">
-      <main className="container mx-auto px-4 py-16 sm:px-6 lg:px-8 pt-24">
+      <main className="container mx-auto px-4 py-16 sm:px-6 lg:px-8 pt-32 sm:pt-24">
         <div className="max-w-4xl mx-auto">
           <h1 className="text-4xl font-bold text-gray-700 mb-8 text-center">About Me</h1>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import HomeNavButtons from "@/components/HomeNavButtons";
 export default function Home() {
   return (
     <div className="min-h-screen bg-gradient-to-b from-rose-50 via-pink-50 to-purple-50">
-      <main className="container mx-auto px-4 py-16 sm:px-6 lg:px-8 pt-24">
+      <main className="container mx-auto px-4 py-16 sm:px-6 lg:px-8 pt-32 sm:pt-24">
 
         <Profile />
 

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -3,7 +3,7 @@ import Projects from "@/components/Projects";
 export default function ProjectsPage() {
   return (
     <div className="min-h-screen bg-gradient-to-b from-rose-50 via-pink-50 to-purple-50">
-      <main className="container mx-auto px-4 py-16 sm:px-6 lg:px-8 pt-24">
+      <main className="container mx-auto px-4 py-16 sm:px-6 lg:px-8 pt-32 sm:pt-24">
         <div className="w-full">
           <h1 className="text-4xl font-bold text-gray-700 mb-8 text-center">My Projects</h1>
           <p className="text-md text-gray-500 text-center mb-12">


### PR DESCRIPTION
## Summary
- Increase top padding on About, Home, and Projects pages for small screens so fixed header doesn't cover page titles

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc7bbe7b38832dbd1bc4fe7d2bdb9b